### PR TITLE
Manual configuration bugfixes

### DIFF
--- a/AgreementMakerLight/src/aml/Main.java
+++ b/AgreementMakerLight/src/aml/Main.java
@@ -372,7 +372,7 @@ public class Main
 				{
 					if(option[1].equalsIgnoreCase("none"))
 						continue;
-					selection.add(MatchStep.PROPERTY);
+					selection.add(MatchStep.SELECT);
 					if(!option[1].equalsIgnoreCase("auto"))
 						aml.setSelectionType(SelectionType.parseSelector(option[1]));
 				}
@@ -383,6 +383,7 @@ public class Main
 				}
 			}
 			in.close();
+			aml.setMatchSteps(selection);
 		}
 		catch(Exception e)
 		{


### PR DESCRIPTION
Two fixes for manual configuration setup:
- Set SELECT matchstep instead of PROPERTY matchstep when selector is enabled in config
- Overwrite default config with manual config after reading